### PR TITLE
Make artist name a link to search

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -227,6 +227,8 @@ main {
 .album-meta { flex: 1; }
 .album-meta h1 { font-size: 1.8rem; margin-bottom: 0.4rem; }
 .album-meta .artist { color: var(--text-2); font-size: 1.1rem; margin-bottom: 1.25rem; }
+.album-meta .artist a { color: inherit; text-decoration: underline; text-decoration-color: var(--border); }
+.album-meta .artist a:hover { text-decoration-color: var(--text-2); }
 .track-subtitle { font-size: 0.95rem; color: var(--text-3); margin-top: -0.75rem; margin-bottom: 1.25rem; }
 .track-subtitle a { color: inherit; text-decoration: none; }
 .track-subtitle a:hover { text-decoration: underline; }

--- a/templates/album.html
+++ b/templates/album.html
@@ -7,7 +7,7 @@
     <img src="{{ tracks[0].artwork_url }}" alt="{{ tracks[0].album }}" class="album-art">
     <div class="album-meta">
       <h1>{{ tracks[0].album }}</h1>
-      <p class="artist">{{ tracks[0].artist }}</p>
+      <p class="artist"><a href="/?q={{ tracks[0].artist | urlencode }}&type=album">{{ tracks[0].artist }}</a></p>
       <p class="tag-string">Tag: <code>apple:{{ album_id }}</code></p>
 
       <div class="action-btns">

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,11 +54,21 @@
     timer = setTimeout(() => fetchResults(q), 300);
   });
 
-  // Pre-fill from ?q= URL param (e.g. from Now Playing search link)
-  const urlQ = new URLSearchParams(window.location.search).get('q');
+  // Pre-fill from ?q= and ?type= URL params (e.g. from artist links)
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlQ = urlParams.get('q');
+  const urlType = urlParams.get('type');
+  if (urlType) {
+    const targetBtn = [...tabBtns].find(b => b.dataset.type === urlType);
+    if (targetBtn) {
+      tabBtns.forEach(b => b.classList.remove('active'));
+      targetBtn.classList.add('active');
+      activeType = urlType;
+    }
+  }
   if (urlQ && !input.value.trim()) { input.value = urlQ; }
 
-  // Re-run search if the browser restored a value or ?q= param was set
+  // Re-run search if the browser restored a value or ?q= / ?type= param was set
   if (input.value.trim()) { clearBtn.style.display = 'flex'; fetchResults(input.value.trim()); }
 
   async function fetchResults(q) {

--- a/templates/track.html
+++ b/templates/track.html
@@ -7,7 +7,7 @@
     <img src="{{ track.artwork_url }}" alt="{{ track.album }}" class="album-art">
     <div class="album-meta">
       <h1>{{ track.name }}</h1>
-      <p class="artist">{{ track.artist }}</p>
+      <p class="artist"><a href="/?q={{ track.artist | urlencode }}&type=album">{{ track.artist }}</a></p>
       <p class="track-subtitle">
         {% if track.album_id %}
           <a href="/album/{{ track.album_id }}">{{ track.album }}</a>


### PR DESCRIPTION
## What

Artist name on album and track pages is now a link. Clicking it navigates to the search page pre-filled with the artist name and the Albums tab selected.

## Why

Closes #33

## Test plan

- [x] Tests pass (`pytest tests/ -v`)
- [ ] Click artist name on an album page → search opens with Albums tab active and results showing
- [ ] Click artist name on a track page → same