### PR TITLE
Fix song search 404 with SMAPI non-numeric track IDs

### DIFF
--- a/providers/apple_music.py
+++ b/providers/apple_music.py
@@ -180,10 +180,15 @@ class AppleMusicProvider(MusicProvider):
             if item.get("item_type") != "track":
                 continue
             track_id = item.get("id", "")
-            if track_id.startswith("track:"):
-                track_id = track_id[6:]
+            for prefix in ("track:", "song:"):
+                if track_id.startswith(prefix):
+                    track_id = track_id[len(prefix):]
+                    break
+            # Skip non-numeric IDs — they cannot be looked up via the iTunes API
+            if not track_id.isdigit():
+                continue
             results.append({
-                "id": int(track_id) if track_id.isdigit() else track_id,
+                "id": int(track_id),
                 "name": item.get("title", ""),
                 "artist": item.get("artist", ""),
                 "album": item.get("album", ""),

--- a/tests/test_apple_music.py
+++ b/tests/test_apple_music.py
@@ -253,6 +253,29 @@ class TestSmapiSearchSongs:
         assert len(results) == 1
         assert results[0]["name"] == "Song"
 
+    def test_strips_song_prefix(self):
+        p = _make_smapi_provider()
+        p._smapi.search = MagicMock(return_value=([
+            {"id": "song:12345", "title": "Song", "artist": "A",
+             "album": "B", "item_type": "track", "album_art_uri": ""},
+        ], 1))
+        results = p.search_songs("test")
+        assert len(results) == 1
+        assert results[0]["id"] == 12345
+
+    def test_skips_non_numeric_ids(self):
+        p = _make_smapi_provider()
+        p._smapi.search = MagicMock(return_value=([
+            {"id": "track:p.LibraryOnlyXYZ", "title": "Library Track", "artist": "A",
+             "album": "B", "item_type": "track", "album_art_uri": ""},
+            {"id": "track:99999", "title": "Catalog Track", "artist": "A",
+             "album": "B", "item_type": "track", "album_art_uri": ""},
+        ], 2))
+        results = p.search_songs("test")
+        assert len(results) == 1
+        assert results[0]["id"] == 99999
+        assert results[0]["name"] == "Catalog Track"
+
 
 class TestSmapiAutoRefresh:
     def test_refreshes_token_on_auth_expired(self):


### PR DESCRIPTION
## What

When SMAPI is configured, song search results could include tracks with non-numeric IDs (library-only tracks, or IDs with prefixes other than `track:`). Clicking those results hit `/track/<non-integer>` which doesn't match the route → 404.

Fix: strip both `"track:"` and `"song:"` prefixes; skip any result that doesn't resolve to a numeric iTunes catalog ID. Those tracks can't be looked up via the iTunes API regardless, so excluding them from results is correct.

## Why

Closes #35

## Test plan

- [x] Tests pass (`pytest tests/ -v`)
- [ ] Search for songs with SMAPI configured — all results should be clickable