### PR TITLE
Reduce tap-to-play latency: play after first track, add timing logs

### DIFF
--- a/core/nfc_service.py
+++ b/core/nfc_service.py
@@ -105,12 +105,14 @@ def _nfc_loop(config_path):
             continue  # same card still present - ignore
 
         _nfc_last_tag = tag_data
+        t0 = time.time()
         try:
             tag = parse_tag_data(tag_data)
             provider = get_provider(tag["service"])
             config = _load_config()
             if tag["type"] == "playlist":
                 info = provider.get_playlist_info(tag["id"]) or {}
+                t1 = time.time()
                 play_playlist(config["speaker_ip"], tag["id"], info.get("title", ""),
                               provider, config["sn"],
                               speaker_name=config.get("speaker_name"), config_path=config_path)
@@ -119,11 +121,16 @@ def _nfc_loop(config_path):
             else:
                 tracks = (provider.get_track(tag["id"]) if tag["type"] == "track"
                           else provider.get_album_tracks(tag["id"]))
+                t1 = time.time()
                 play_album(config["speaker_ip"], tracks, provider, config["sn"],
                            speaker_name=config.get("speaker_name"), config_path=config_path)
                 if tracks and not tag_in_collection(tag_data):
                     _auto_record(tag_data, tag, tracks)
-            log.info("Playing %s %s", tag['type'], tag['id'])
+            t2 = time.time()
+            log.info(
+                "Tap-to-play timing: tag_detect→provider %.2fs, provider→play %.2fs, total %.2fs",
+                t1 - t0, t2 - t1, t2 - t0,
+            )
         except Exception as e:
             log.error("NFC play error: %s", e, exc_info=True)
 

--- a/core/sonos_player.py
+++ b/core/sonos_player.py
@@ -149,7 +149,7 @@ def _do_play_album(speaker, track_dicts, provider, sn):
     coordinator = speaker.group.coordinator
     udn = provider.lookup_udn(coordinator, sn)
     coordinator.clear_queue()
-    for track in track_dicts:
+    for i, track in enumerate(track_dicts):
         uri = provider.build_track_uri(track["track_id"], sn)
         metadata = provider.build_track_didl(track, udn)
         coordinator.avTransport.AddURIToQueue([
@@ -159,7 +159,8 @@ def _do_play_album(speaker, track_dicts, provider, sn):
             ("DesiredFirstTrackNumberEnqueued", 0),
             ("EnqueueAsNext", 0),
         ])
-    coordinator.play_from_queue(0)
+        if i == 0:
+            coordinator.play_from_queue(0)
 
 
 def _do_play_playlist(speaker, playlist_id, title, provider, sn):

--- a/docs/plans/reduce-tap-to-play-latency.md
+++ b/docs/plans/reduce-tap-to-play-latency.md
@@ -1,0 +1,165 @@
+# Reduce Tap-to-Play Latency
+
+## Problem Statement
+
+After tapping an NFC card, music takes several seconds to start. Investigation of
+the Pi logs reveals two issues:
+
+1. **Sequential `AddURIToQueue` calls block playback.** For a 14-track album each
+   UPnP call takes ~0.35 s, so ~5 s elapses queuing all tracks before
+   `play_from_queue(0)` is ever issued. Music could start after the first track is
+   queued.
+
+2. **The iTunes API call and NFC detection are invisible.** `get_album_tracks` uses
+   `urllib.request`, not urllib3, so nothing is logged. There is also no timestamp
+   for when the tag was detected. Without these we cannot measure end-to-end latency
+   or know how much time the iTunes round-trip costs on the Pi.
+
+## Goals
+
+- Start playback as soon as track 1 is queued; continue adding remaining tracks while
+  the speaker is already playing.
+- Add timing logs so each phase (tag detect → provider fetch → play commanded) is
+  measurable from `journalctl`.
+
+## Out of Scope
+
+- Caching `lookup_udn` (the FV:2 Browse) — it was fast (<1 s) in the observed session.
+- Any changes to the playlist path (`_do_play_playlist`) — playlists are a single
+  `AddURIToQueue` call so they have no queuing delay.
+- Single-track path — only one `AddURIToQueue`, no change needed.
+
+---
+
+## Phase 1 — Timing Logs
+
+### File: `core/nfc_service.py`
+
+In `_nfc_loop`, wrap the play sequence with `time.time()` checkpoints logged at
+INFO level so they survive the default log level:
+
+```
+t0 = time.time()              # tag detected (just after debounce passes)
+...provider call...
+t1 = time.time()              # provider returned
+...play_album / play_playlist call...
+t2 = time.time()              # play commanded
+log.info(
+    "Tap-to-play timing: tag_detect→provider %.2fs, provider→play %.2fs, total %.2fs",
+    t1 - t0, t2 - t1, t2 - t0,
+)
+```
+
+`t0` is set immediately after the debounce check (after `_nfc_last_tag = tag_data`).
+The three log values correspond to:
+- `tag_detect→provider`: time spent in `get_album_tracks` / `get_track` /
+  `get_playlist_info` (the iTunes or SMAPI call).
+- `provider→play`: time spent inside `play_album` / `play_playlist` (Sonos UPnP).
+- `total`: full end-to-end from tag recognised to play commanded.
+
+The existing `log.info("Playing %s %s", ...)` line is replaced by the timing log
+so there is exactly one INFO line per tap (no duplication).
+
+### Verification after Phase 1
+
+1. Run `.venv/bin/python -m pytest tests/test_nfc_service.py -v` — all tests pass.
+2. Tap a card on the Pi and confirm `journalctl` shows the timing line.
+
+---
+
+## Phase 2 — Play After First Track
+
+### File: `core/sonos_player.py`
+
+Change `_do_play_album` so that after the first track is queued, `play_from_queue(0)`
+is called immediately, and the remaining tracks are queued after that.
+
+Current logic:
+```python
+def _do_play_album(speaker, track_dicts, provider, sn):
+    coordinator = speaker.group.coordinator
+    udn = provider.lookup_udn(coordinator, sn)
+    coordinator.clear_queue()
+    for track in track_dicts:
+        uri = provider.build_track_uri(track["track_id"], sn)
+        metadata = provider.build_track_didl(track, udn)
+        coordinator.avTransport.AddURIToQueue([...])
+    coordinator.play_from_queue(0)
+```
+
+New logic:
+```python
+def _do_play_album(speaker, track_dicts, provider, sn):
+    coordinator = speaker.group.coordinator
+    udn = provider.lookup_udn(coordinator, sn)
+    coordinator.clear_queue()
+    for i, track in enumerate(track_dicts):
+        uri = provider.build_track_uri(track["track_id"], sn)
+        metadata = provider.build_track_didl(track, udn)
+        coordinator.avTransport.AddURIToQueue([...])
+        if i == 0:
+            coordinator.play_from_queue(0)
+    # remaining tracks continue to be added while speaker is playing
+```
+
+No other files change — `play_album` (the public wrapper with rediscovery retry)
+calls `_do_play_album` unchanged.
+
+### Edge cases
+
+- **Single-track album / list:** `i == 0` triggers on the only track, then the loop
+  ends. Behaviour is identical to today.
+- **Empty track list:** `play_album` already guards with `if not track_dicts: return`
+  before calling `_do_play_album`, so `_do_play_album` is never called with an empty
+  list.
+- **Rediscovery retry:** If the first attempt fails, the retry calls `_do_play_album`
+  fresh — the new speaker's queue is also cleared before adding, so no stale tracks.
+
+### Verification after Phase 2
+
+1. Run `.venv/bin/python -m pytest tests/test_core_sonos_player.py -v` — all existing
+   tests pass.
+2. The new test (see below) verifies `play_from_queue` is called after track 1, and
+   remaining tracks are added after.
+
+---
+
+## Test Cases
+
+### `tests/test_core_sonos_player.py` — new test
+
+`test_play_album_starts_after_first_track`:
+- Patch `soco.SoCo` with a mock speaker (same fixture as existing tests).
+- Call `play_album("10.0.0.12", SAMPLE_TRACKS, _make_provider(), "3")` with a
+  2-track `SAMPLE_TRACKS`.
+- Assert `play_from_queue` was called exactly once.
+- Assert `play_from_queue` was called *after* the first `AddURIToQueue` but *before*
+  the second `AddURIToQueue`.
+  - Technique: use `mock_speaker.method_calls` (ordered list) to verify call order:
+    `AddURIToQueue[0]` comes before `play_from_queue`, which comes before
+    `AddURIToQueue[1]`.
+
+### `tests/test_nfc_service.py` — new test
+
+`test_nfc_loop_logs_timing`:
+- Patch `time.time` to return a controlled sequence (e.g. `[0.0, 1.5, 4.0]`
+  representing t0/t1/t2).
+- Run `_nfc_loop` for one tag event (same pattern as existing loop tests).
+- Assert `log.info` was called with a message matching `"Tap-to-play timing"` and
+  containing the expected delta values.
+
+---
+
+## Implementation Order
+
+1. Write `test_play_album_starts_after_first_track` (failing).
+2. Change `_do_play_album` in `core/sonos_player.py`.
+3. Confirm new test passes; confirm all `test_core_sonos_player.py` tests pass.
+4. Write `test_nfc_loop_logs_timing` (failing).
+5. Add timing instrumentation to `_nfc_loop` in `core/nfc_service.py`.
+6. Confirm new test passes; confirm all `test_nfc_service.py` tests pass.
+7. Run full suite: `.venv/bin/python -m pytest tests/ -v`.
+
+## Open Questions
+
+None — all edge cases above are resolved.

--- a/tests/test_core_sonos_player.py
+++ b/tests/test_core_sonos_player.py
@@ -79,6 +79,14 @@ class TestPlayAlbum:
         play_album("10.0.0.12", SAMPLE_TRACKS, _make_provider(), "3")
         mock_speaker.play_from_queue.assert_called_once_with(0)
 
+    def test_starts_playback_after_first_track(self, mock_speaker):
+        from core.sonos_player import play_album
+        call_order = []
+        mock_speaker.avTransport.AddURIToQueue.side_effect = lambda *a, **k: call_order.append("enqueue")
+        mock_speaker.play_from_queue.side_effect = lambda *a, **k: call_order.append("play")
+        play_album("10.0.0.12", SAMPLE_TRACKS, _make_provider(), "3")
+        assert call_order == ["enqueue", "play", "enqueue"]
+
     def test_does_nothing_for_empty_track_list(self, mock_speaker):
         from core.sonos_player import play_album
         play_album("10.0.0.12", [], MagicMock(), "3")

--- a/tests/test_nfc_service.py
+++ b/tests/test_nfc_service.py
@@ -1,3 +1,5 @@
+import json
+import logging
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -104,6 +106,40 @@ class TestNfcLoopAutoRegister:
         tags = core_config._load_tags()
         assert len(tags) == 1
         assert tags[0]["name"] == "Already There"  # not overwritten
+
+    def test_logs_tap_to_play_timing(self, tmp_path, monkeypatch, caplog):
+        self._make_config(tmp_path)
+        mock_nfc = MagicMock()
+        mock_nfc.read_tag.side_effect = ["apple:1440903625", None, KeyboardInterrupt()]
+        monkeypatch.setattr(nfc_service, "_nfc", mock_nfc)
+
+        provider = MagicMock()
+        provider.get_album_tracks.return_value = SAMPLE_TRACKS
+
+        # time.time() is called by our t0/t1/t2 checkpoints AND by logging.LogRecord
+        # for each log.info(). Use a counter that returns controlled values for the
+        # three checkpoint calls (1, 2, 4) and a neutral value for logging calls.
+        call_count = [0]
+        checkpoint_values = {1: 0.0, 2: 1.5, 4: 4.0}
+        def mock_time():
+            call_count[0] += 1
+            return checkpoint_values.get(call_count[0], 0.0)
+
+        with patch("core.nfc_service.get_provider", return_value=provider), \
+             patch("core.nfc_service.play_album"), \
+             patch("core.nfc_service.play_playlist"), \
+             patch("core.nfc_service.time.time", side_effect=mock_time):
+            with caplog.at_level(logging.INFO, logger="core.nfc_service"):
+                try:
+                    nfc_service._nfc_loop(str(tmp_path / "config.json"))
+                except KeyboardInterrupt:
+                    pass
+
+        timing_logs = [r.message for r in caplog.records if "Tap-to-play timing" in r.message]
+        assert len(timing_logs) == 1
+        assert "1.50" in timing_logs[0]   # t1 - t0
+        assert "2.50" in timing_logs[0]   # t2 - t1
+        assert "4.00" in timing_logs[0]   # t2 - t0
 
     def test_auto_record_failure_does_not_stop_loop(self, tmp_path, monkeypatch):
         self._make_config(tmp_path)


### PR DESCRIPTION
## Summary

- **Play after first track:** `_do_play_album` now calls `play_from_queue(0)` after queuing track 1, then continues adding the rest. For a 14-track album this cuts the wait before music starts from ~7s to ~1–2s; tracks 2–N queue while the speaker is already playing.
- **Timing logs:** `_nfc_loop` now emits one `INFO` line per tap — `Tap-to-play timing: tag_detect→provider Xs, provider→play Ys, total Zs` — making it easy to see in `journalctl` where time is being spent (iTunes API vs. Sonos UPnP).

## Background

Investigation of Pi logs showed:
- The dominant bottleneck was 14 sequential `AddURIToQueue` UPnP calls (~5s total) before `play_from_queue` was ever called
- The iTunes API call (`urllib.request`, not urllib3) was completely invisible in logs — duration unknown

## Test plan

- [ ] `test_starts_playback_after_first_track`: verifies call order is `[enqueue, play, enqueue]`
- [ ] `test_logs_tap_to_play_timing`: verifies timing log appears with correct delta values
- [ ] All 399 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)