### PR TITLE
Fix Invalid Date for timezone-aware written_at timestamps

### DIFF
--- a/templates/collection.html
+++ b/templates/collection.html
@@ -35,7 +35,8 @@
   let filterQuery = '';
 
   function formatDate(iso) {
-    const d = new Date(iso + 'Z');
+    const normalized = iso.includes('+') || iso.endsWith('Z') ? iso : iso + 'Z';
+    const d = new Date(normalized);
     return d.toLocaleDateString(undefined, {month: 'short', day: 'numeric', year: 'numeric'});
   }
 


### PR DESCRIPTION
## Summary
- `formatDate` in the Collection page was appending `'Z'` to all ISO timestamps unconditionally
- Tags written by `record_tag` (since c745b83) include a `+00:00` suffix, producing invalid strings like `2026-03-31T17:42:10+00:00Z`
- Older tags without a timezone suffix were unaffected, which is why some dates displayed correctly and others showed \"Invalid Date\"
- Fix: normalize the string first — only append `'Z'` if no timezone info is present

## Test plan
- [ ] All 399 existing tests pass
- [ ] Load `/collection` and confirm all dates render correctly for both old (no-tz) and new (+00:00) entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)